### PR TITLE
PHP 8.2 compatibility

### DIFF
--- a/src/Service/Logger.php
+++ b/src/Service/Logger.php
@@ -20,8 +20,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class Logger {
 
-  const string OS2WEB_AUDIT_QUEUE_ID = 'os2web_audit';
-  const string OS2WEB_AUDIT_LOGGER_CHANNEL = 'os2web_audit_info';
+  public const OS2WEB_AUDIT_QUEUE_ID = 'os2web_audit';
+  public const OS2WEB_AUDIT_LOGGER_CHANNEL = 'os2web_audit_info';
 
   public function __construct(
     private readonly LoggerManager $loggerManager,


### PR DESCRIPTION
This piece of code is not compatible with php 8.2 and below.

I am suggesting a change that will also make it compatible with lower PHP versions

#### Link to ticket

Please add a link to the ticket being addressed by this change.

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
